### PR TITLE
chore: activate snippet-bot at the org level

### DIFF
--- a/snippet-bot.yml
+++ b/snippet-bot.yml
@@ -1,0 +1,1 @@
+# An empty config just to activate snippet-bot


### PR DESCRIPTION
To activate snippet-bot we need a config file to be present.