### PR TITLE
chore: add sync repo settings config

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,65 @@
+configs:
+- name: java
+  selector: "org:googleapis is:public archived:false language:java"
+  rebaseMergeAllowed: false
+  branchProtectionRules:
+  - requiresCodeOwnerReviews: true
+    requiredStatusCheckContexts:
+    - dependencies (8)
+    - dependencies (11)
+    - linkage-monitor
+    - lint
+    - clirr
+    - units (7)
+    - units (8)
+    - units (11)
+    - 'Kokoro - Test: Integration'
+    - cla/google
+  permissionRules:
+  - team: java-samples-reviewers
+    permission: push
+  - team: yoshi-admins
+    permission: admin
+  - team: yoshi-java-admins
+    permission: admin
+  - team: yoshi-java
+    permission: push
+- name: python
+  branchProtectionRules:
+  - requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: true
+    requiredStatusCheckContexts:
+    - Kokoro
+    - cla/google
+  permissionRules:
+  - team: yoshi-admins
+    permission: admin
+  - team: yoshi-python-admins
+    permission: admin
+  - team: yoshi-python
+    permission: push
+  - team: python-samples-owners
+    permission: push
+- name: nodejs
+  selector: "org:googleapis is:public archived:false language:javascript language:typescript"
+  branchProtectionRules:
+  - requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: true
+    requiredStatusCheckContexts:
+    - 'ci/kokoro: Samples test'
+    - 'ci/kokoro: System test'
+    - docs
+    - lint
+    - test (10)
+    - test (12)
+    - test (14)
+    - test (15)
+    - cla/google
+    - windows
+  permissionRules:
+  - team: yoshi-admins
+    permission: admin
+  - team: yoshi-nodejs-admins
+    permission: admin
+  - team: yoshi-nodejs
+    permission: push


### PR DESCRIPTION
I am trying to to remove centralized config from sync-repo-settings bot.  The plan is to create a default config here which can be overridden on a per-repo basis.  This is blocked on the actual changes landing in the bot.  