### PR TITLE
Add exceptions to BP policy for direct-push repositories.

### DIFF
--- a/allstar/branch_protection.yaml
+++ b/allstar/branch_protection.yaml
@@ -1,5 +1,10 @@
 optConfig:
   optOutStrategy: true
   disableRepoOverride: true
+  optOutRepos:
+  # Pushed by copybara directly
+  - googleapis
+  # Pushed by Bazel Bot directly
+  - googleapis-gen
 action: issue
 dismissStale: false


### PR DESCRIPTION
@bcoe This config will opt-out those repos from Branch Protection but leave them enabled for the other policies. All other repos for which Allstar is enabled will have the BP policy enabled.

Note: currently those repos are not enabled at the Allstar level, so this PR doesn't do anything.