### PR TITLE
chore: remove labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: 'type: bug, priority: p2'
 ---
 
 Thanks for stopping by to let us know something could be better!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an idea for this library
-labels: 'type: feature request, priority: p3'
 ---
 
 Thanks for stopping by to let us know something could be better!

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,6 @@
 ---
 name: Question
 about: Ask a question
-labels: 'type: question, priority: p3'
 ---
 
 Thanks for stopping by to ask us a question! Please make sure to include:


### PR DESCRIPTION
Given the current workflow for triaging issues (unlabeled issues show up on dashboards), I think not applying any labels by default is better for visibility.